### PR TITLE
fix(logging): clone tags before write and honor call-site tags

### DIFF
--- a/pkg/logging/handler.go
+++ b/pkg/logging/handler.go
@@ -28,7 +28,13 @@ func ConfigureLoggerWithWriter(w io.Writer, level LogLevel) {
 	slog.SetDefault(logger)
 }
 
-func GetLoggerFromContext(ctx context.Context) *slog.Logger {
+// GetLoggerFromContext returns a logger carrying the ctx-accumulated tags
+// merged with extra (call-site Tags win on a key collision). Both must be
+// folded into a single Tags map before the *one* With() call below: slog
+// doesn't dedupe attributes by key, so applying ctx tags and extra as two
+// separate With() calls would emit a colliding key twice instead of letting
+// the call-site value override it.
+func GetLoggerFromContext(ctx context.Context, extra Tags) *slog.Logger {
 	traceInfo := ExtractTraceInfo(ctx)
 
 	loggerWithTrace := logger
@@ -39,10 +45,10 @@ func GetLoggerFromContext(ctx context.Context) *slog.Logger {
 		)
 	}
 
-	ctxTags := getTags(ctx)
-	if len(ctxTags) > 0 {
-		attrs := make([]any, 0, len(ctxTags)*2)
-		for k, v := range ctxTags {
+	tags := mergeCtxTags(ctx, extra)
+	if len(tags) > 0 {
+		attrs := make([]any, 0, len(tags)*2)
+		for k, v := range tags {
 			attrs = append(attrs, slog.Any(k, v))
 		}
 		loggerWithTrace = loggerWithTrace.With(attrs...)
@@ -51,7 +57,9 @@ func GetLoggerFromContext(ctx context.Context) *slog.Logger {
 	return loggerWithTrace
 }
 
-func GetOtelLoggerFromContext(ctx context.Context) otellog.Record {
+// GetOtelLoggerFromContext mirrors GetLoggerFromContext's merge-before-emit
+// rule for the otel Record: AddAttributes doesn't dedupe by key either.
+func GetOtelLoggerFromContext(ctx context.Context, extra Tags) otellog.Record {
 	traceInfo := ExtractTraceInfo(ctx)
 	otelRecord := otellog.Record{}
 
@@ -63,11 +71,11 @@ func GetOtelLoggerFromContext(ctx context.Context) otellog.Record {
 			Key:   "span_id",
 			Value: otellog.StringValue(traceInfo.SpanID),
 		})
-	}
+	} 
 
-	ctxTags := getTags(ctx)
-	if len(ctxTags) > 0 {
-		for k, v := range ctxTags {
+	tags := mergeCtxTags(ctx, extra)
+	if len(tags) > 0 {
+		for k, v := range tags {
 			otelRecord.AddAttributes(otellog.KeyValue{
 				Key:   k,
 				Value: otellog.StringValue(fmt.Sprintf("%v", v)),

--- a/pkg/logging/handler.go
+++ b/pkg/logging/handler.go
@@ -71,7 +71,7 @@ func GetOtelLoggerFromContext(ctx context.Context, extra Tags) otellog.Record {
 			Key:   "span_id",
 			Value: otellog.StringValue(traceInfo.SpanID),
 		})
-	} 
+	}
 
 	tags := mergeCtxTags(ctx, extra)
 	if len(tags) > 0 {

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -72,7 +72,6 @@ func SetLoggingLevel(level LogLevel) {
 func Log(ctx context.Context, level LogLevel, msg string, opts ...any) {
 	args := []any{}
 	tags := Tags{}
-	maps.Copy(tags, getTags(ctx))
 	for _, opt := range opts {
 		switch opt := opt.(type) {
 		case Tags:
@@ -101,7 +100,11 @@ func Error(ctx context.Context, msg string, opts ...any) {
 }
 
 func printf(ctx context.Context, app string, level LogLevel, t Tags, msg string, v ...any) {
-	ctxLogger := GetLoggerFromContext(ctx)
+	// t holds only call-site Tags (logging.Info(ctx, msg, logging.Tags{...})).
+	// GetLoggerFromContext merges it with the ctx tags itself and applies the
+	// result in one With() call — see its doc comment for why a second,
+	// independent With() here would double-emit any colliding key.
+	ctxLogger := GetLoggerFromContext(ctx, t)
 
 	formattedMsg := msg
 	if len(v) > 0 {
@@ -109,15 +112,15 @@ func printf(ctx context.Context, app string, level LogLevel, t Tags, msg string,
 	}
 
 	ctxLogger.LogAttrs(ctx, slog.Level(level), fmt.Sprintf("%s", formattedMsg))
-	otelPrintf(ctx, level, formattedMsg)
+	otelPrintf(ctx, level, formattedMsg, t)
 }
 
-func otelPrintf(ctx context.Context, level LogLevel, msg string) {
+func otelPrintf(ctx context.Context, level LogLevel, msg string, t Tags) {
 	if otelLogger == nil {
 		return
 	}
 
-	otelRecord := GetOtelLoggerFromContext(ctx)
+	otelRecord := GetOtelLoggerFromContext(ctx, t)
 	otelRecord.SetBody(otellog.StringValue(msg))
 	otelRecord.SetSeverity(level.OtelString())
 	otelLogger.Emit(ctx, otelRecord)
@@ -125,7 +128,6 @@ func otelPrintf(ctx context.Context, level LogLevel, msg string) {
 
 func Err(ctx context.Context, err error, tags ...Tags) {
 	t := Tags{}
-	maps.Copy(t, getTags(ctx))
 	for _, tag := range tags {
 		t = t.Merge(tag)
 	}

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -111,7 +111,7 @@ func printf(ctx context.Context, app string, level LogLevel, t Tags, msg string,
 		formattedMsg = fmt.Sprintf(msg, v...)
 	}
 
-	ctxLogger.LogAttrs(ctx, slog.Level(level), fmt.Sprintf("%s", formattedMsg))
+	ctxLogger.LogAttrs(ctx, slog.Level(level), formattedMsg)
 	otelPrintf(ctx, level, formattedMsg, t)
 }
 

--- a/pkg/logging/log_test.go
+++ b/pkg/logging/log_test.go
@@ -1,0 +1,239 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	otellog "go.opentelemetry.io/otel/log"
+	otellognoop "go.opentelemetry.io/otel/log/noop"
+)
+
+// syncBuffer lets concurrent test goroutines share one destination safely;
+// it does not exercise slog's own internal write locking.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Lines() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := strings.TrimSpace(b.buf.String())
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
+func TestLogCallSiteTagsAppearInJSONOutput(t *testing.T) {
+	prevLogger := logger
+	defer func() { logger = prevLogger }()
+
+	buf := &syncBuffer{}
+	ConfigureLoggerWithWriter(buf, LogLevelInfo)
+
+	ctx := WithTag(context.Background(), "handler", "TestHandler")
+	Info(ctx, "finished", Tags{"contacts_upserted": 42})
+
+	lines := buf.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("want 1 log line, got %d: %v", len(lines), lines)
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("log line is not valid JSON: %v (%s)", err, lines[0])
+	}
+
+	if entry["msg"] != "finished" {
+		t.Fatalf("got msg=%v, want %q", entry["msg"], "finished")
+	}
+	if entry["handler"] != "TestHandler" {
+		t.Fatalf("missing ctx tag %q in output: %v", "handler", entry)
+	}
+	if entry["contacts_upserted"] != float64(42) {
+		t.Fatalf("missing call-site tag %q in output: %v", "contacts_upserted", entry)
+	}
+}
+
+// TestLogTagsDoNotCrossContaminateConcurrentHandlers is the regression test
+// for the Signoz symptom: two sibling handler goroutines tagging from the
+// same parent ctx must each produce a log line carrying only their own tags.
+func TestLogTagsDoNotCrossContaminateConcurrentHandlers(t *testing.T) {
+	prevLogger := logger
+	defer func() { logger = prevLogger }()
+
+	buf := &syncBuffer{}
+	ConfigureLoggerWithWriter(buf, LogLevelInfo)
+
+	parent := context.Background()
+	handlers := []string{"TicketsHandler", "ProjectsHandler"}
+
+	var wg sync.WaitGroup
+	for _, name := range handlers {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			ctx := WithTag(parent, "handler", name)
+			Info(ctx, "finished", Tags{"upserted": len(name)})
+		}(name)
+	}
+	wg.Wait()
+
+	lines := buf.Lines()
+	if len(lines) != len(handlers) {
+		t.Fatalf("want %d log lines, got %d: %v", len(handlers), len(lines), lines)
+	}
+
+	for _, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("log line is not valid JSON: %v (%s)", err, line)
+		}
+		handler, _ := entry["handler"].(string)
+		wantUpserted := float64(len(handler))
+		if entry["upserted"] != wantUpserted {
+			t.Fatalf("handler %q log line carries a mismatched upserted value (cross-contamination): %v", handler, entry)
+		}
+	}
+}
+
+type recordingOtelLogger struct {
+	otellognoop.Logger
+	mu      sync.Mutex
+	records []otellog.Record
+}
+
+func (r *recordingOtelLogger) Emit(_ context.Context, record otellog.Record) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, record)
+}
+
+func TestLogCallSiteTagsAppearInOtelRecord(t *testing.T) {
+	prev := otelLogger
+	rec := &recordingOtelLogger{}
+	otelLogger = rec
+	defer func() { otelLogger = prev }()
+
+	ctx := WithTag(context.Background(), "handler", "TestHandler")
+	Info(ctx, "finished", Tags{"contacts_upserted": 42})
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.records) != 1 {
+		t.Fatalf("want 1 otel record, got %d", len(rec.records))
+	}
+
+	got := map[string]string{}
+	rec.records[0].WalkAttributes(func(kv otellog.KeyValue) bool {
+		got[kv.Key] = kv.Value.AsString()
+		return true
+	})
+
+	if got["handler"] != "TestHandler" {
+		t.Fatalf("otel record missing ctx tag %q: %+v", "handler", got)
+	}
+	if got["contacts_upserted"] != "42" {
+		t.Fatalf("otel record missing call-site tag %q: %+v", "contacts_upserted", got)
+	}
+}
+
+// TestLogCallSiteTagOverridesCollidingCtxTag guards against a regression
+// where a call-site Tag sharing a key with a ctx tag (e.g. "handler") got
+// applied via a second, independent With()/AddAttributes() call and ended up
+// duplicated in the output instead of overriding the ctx value. json.Unmarshal
+// into a map silently collapses duplicate keys, so this asserts on the raw
+// JSON bytes as well as the parsed value.
+func TestLogCallSiteTagOverridesCollidingCtxTag(t *testing.T) {
+	prevLogger := logger
+	defer func() { logger = prevLogger }()
+	prevOtel := otelLogger
+	rec := &recordingOtelLogger{}
+	otelLogger = rec
+	defer func() { otelLogger = prevOtel }()
+
+	buf := &syncBuffer{}
+	ConfigureLoggerWithWriter(buf, LogLevelInfo)
+
+	ctx := WithTag(context.Background(), "handler", "TicketsHandler")
+	Info(ctx, "processing", Tags{"handler": "override-value"})
+
+	lines := buf.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("want 1 log line, got %d: %v", len(lines), lines)
+	}
+	if n := strings.Count(lines[0], `"handler"`); n != 1 {
+		t.Fatalf("want exactly 1 %q key in JSON output, got %d: %s", "handler", n, lines[0])
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("log line is not valid JSON: %v (%s)", err, lines[0])
+	}
+	if entry["handler"] != "override-value" {
+		t.Fatalf("call-site tag should override the ctx tag, got handler=%v", entry["handler"])
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.records) != 1 {
+		t.Fatalf("want 1 otel record, got %d", len(rec.records))
+	}
+	count := 0
+	var otelValue string
+	rec.records[0].WalkAttributes(func(kv otellog.KeyValue) bool {
+		if kv.Key == "handler" {
+			count++
+			otelValue = kv.Value.AsString()
+		}
+		return true
+	})
+	if count != 1 {
+		t.Fatalf("want exactly 1 otel %q attribute, got %d", "handler", count)
+	}
+	if otelValue != "override-value" {
+		t.Fatalf("otel record should carry the call-site override, got %q", otelValue)
+	}
+}
+
+// TestErrDoesNotDuplicateCollidingCtxErrorTag targets Err()'s hardcoded
+// Tags{"error": true}: if a caller already tagged the ctx with "error"
+// upstream (a guessable key), Err() must not double-emit the attribute.
+func TestErrDoesNotDuplicateCollidingCtxErrorTag(t *testing.T) {
+	prevLogger := logger
+	defer func() { logger = prevLogger }()
+
+	buf := &syncBuffer{}
+	ConfigureLoggerWithWriter(buf, LogLevelInfo)
+
+	ctx := WithTag(context.Background(), "error", "upstream-flag")
+	Err(ctx, errors.New("boom"))
+
+	lines := buf.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("want 1 log line, got %d: %v", len(lines), lines)
+	}
+	if n := strings.Count(lines[0], `"error"`); n != 1 {
+		t.Fatalf("want exactly 1 %q key in JSON output, got %d: %s", "error", n, lines[0])
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("log line is not valid JSON: %v (%s)", err, lines[0])
+	}
+	if entry["error"] != true {
+		t.Fatalf("Err's hardcoded error=true tag should win, got error=%v", entry["error"])
+	}
+}

--- a/pkg/logging/tags.go
+++ b/pkg/logging/tags.go
@@ -14,13 +14,16 @@ type key int
 const tagsKey key = iota
 
 func WithTag(ctx context.Context, key string, value any) context.Context {
-	tags := getTags(ctx)
+	// getTags returns the map by reference: without cloning, sibling goroutines
+	// derived from the same parent ctx would mutate the same map (cross-handler
+	// tag leakage plus a concurrent map write panic under -race).
+	tags := maps.Clone(getTags(ctx))
 	tags[key] = value
 	return context.WithValue(ctx, tagsKey, tags)
 }
 
 func WithTags(ctx context.Context, tags Tags) context.Context {
-	t := getTags(ctx)
+	t := maps.Clone(getTags(ctx))
 	maps.Copy(t, tags)
 	return context.WithValue(ctx, tagsKey, t)
 }
@@ -31,6 +34,17 @@ func getTags(ctx context.Context) Tags {
 		return make(Tags)
 	}
 	return tags.(Tags)
+}
+
+// mergeCtxTags merges the ctx-accumulated tags with call-site extra tags,
+// extra winning on a key collision. Returns the ctx map as-is (read-only
+// here) when there is nothing to merge, to avoid an allocation on the
+// common no-call-site-tags path.
+func mergeCtxTags(ctx context.Context, extra Tags) Tags {
+	if len(extra) == 0 {
+		return getTags(ctx)
+	}
+	return getTags(ctx).Merge(extra)
 }
 
 func (ts Tags) Merge(t Tags) Tags {

--- a/pkg/logging/tags_test.go
+++ b/pkg/logging/tags_test.go
@@ -1,0 +1,110 @@
+package logging
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestWithTagDoesNotMutateParentTags(t *testing.T) {
+	parent := WithTag(context.Background(), "handler", "ParentHandler")
+
+	_ = WithTag(parent, "extra", "child-only")
+
+	parentTags := getTags(parent)
+	if _, ok := parentTags["extra"]; ok {
+		t.Fatalf("parent ctx tags mutated by child WithTag call: %+v", parentTags)
+	}
+	if parentTags["handler"] != "ParentHandler" {
+		t.Fatalf("parent ctx lost its own tag: %+v", parentTags)
+	}
+}
+
+func TestWithTagsDoesNotMutateParentTags(t *testing.T) {
+	parent := WithTags(context.Background(), Tags{"handler": "ParentHandler"})
+
+	_ = WithTags(parent, Tags{"extra": "child-only"})
+
+	parentTags := getTags(parent)
+	if _, ok := parentTags["extra"]; ok {
+		t.Fatalf("parent ctx tags mutated by child WithTags call: %+v", parentTags)
+	}
+}
+
+// TestWithTagConcurrentSiblingsDoNotRace reproduces the ConnectWise
+// tickets/projects orchestrator fan-out (sibling handler goroutines derived
+// from the same parent ctx tagging concurrently) that caused cross-handler
+// log contamination. Pre-fix, getTags(ctx) returned the map by reference and
+// every goroutine wrote into the same map: run with -race and it either
+// reports a data race or the runtime aborts with "concurrent map writes".
+func TestWithTagConcurrentSiblingsDoNotRace(t *testing.T) {
+	const n = 100
+	parent := WithTag(context.Background(), "seed", "root")
+
+	var wg sync.WaitGroup
+	seen := make([]Tags, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx := WithTag(parent, "id", i)
+			ctx = WithTags(ctx, Tags{"squared": i * i})
+			seen[i] = getTags(ctx)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, tags := range seen {
+		if tags["id"] != i {
+			t.Fatalf("goroutine %d: got id=%v, want %d (cross-goroutine contamination)", i, tags["id"], i)
+		}
+		if tags["squared"] != i*i {
+			t.Fatalf("goroutine %d: got squared=%v, want %d", i, tags["squared"], i*i)
+		}
+		if tags["seed"] != "root" {
+			t.Fatalf("goroutine %d: lost ancestor tag: %+v", i, tags)
+		}
+	}
+
+	if _, ok := getTags(parent)["id"]; ok {
+		t.Fatalf("parent ctx mutated by child goroutines: %+v", getTags(parent))
+	}
+}
+
+// TestWithTagsConcurrentSiblingsDoNotRace is the WithTags counterpart of
+// TestWithTagConcurrentSiblingsDoNotRace: it calls WithTags directly on the
+// shared parent ctx from every goroutine (not on an already goroutine-private
+// derived ctx), so it actually stresses WithTags's own clone against the
+// shared map instead of a copy WithTag already made private.
+func TestWithTagsConcurrentSiblingsDoNotRace(t *testing.T) {
+	const n = 100
+	parent := WithTags(context.Background(), Tags{"seed": "root"})
+
+	var wg sync.WaitGroup
+	seen := make([]Tags, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx := WithTags(parent, Tags{"id": i, "squared": i * i})
+			seen[i] = getTags(ctx)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, tags := range seen {
+		if tags["id"] != i {
+			t.Fatalf("goroutine %d: got id=%v, want %d (cross-goroutine contamination)", i, tags["id"], i)
+		}
+		if tags["squared"] != i*i {
+			t.Fatalf("goroutine %d: got squared=%v, want %d", i, tags["squared"], i*i)
+		}
+		if tags["seed"] != "root" {
+			t.Fatalf("goroutine %d: lost ancestor tag: %+v", i, tags)
+		}
+	}
+
+	if _, ok := getTags(parent)["id"]; ok {
+		t.Fatalf("parent ctx mutated by child goroutines: %+v", getTags(parent))
+	}
+}


### PR DESCRIPTION
## O problema real

Isso é a **Fase B** de um bug que já tinha sido parcialmente corrigido no `crewhu-trends-api` (Fase A). O sintoma original em produção era um crash no upsert de contacts, mas ao investigar o log de erro no Signoz, o time notou algo estranho: **o erro do handler de "projects" aparecia carimbado com atributos que pertenciam ao handler de "tickets"** (`read`, `upserted`, `invalid_dates` — coisas que só o tickets handler produz).

Isso não era um erro de log cosmético — era sintoma de um bug de concorrência real na biblioteca compartilhada de observabilidade (`observability_go`), usada por todos os handlers.

### Causa raiz

O orchestrator do worker roda os handlers do ConnectWise (tickets, projects, etc.) **em goroutines concorrentes**, todas derivadas do **mesmo contexto (`ctx`) pai**. Cada handler, ao processar, ia "carimbando" esse ctx com tags de identificação via `WithTag`/`WithTags` (ex.: `handler=TicketsHandler`, `upserted=120`).

O problema: essas funções da lib pegavam o mapa de tags do ctx **e escreviam nele diretamente**, em vez de fazer uma cópia. Como `context.Context` é uma árvore compartilhada entre as goroutines-irmãs, isso significava que **todas as goroutines estavam escrevendo no mesmo mapa em memória, ao mesmo tempo**. Duas consequências:

1. **Vazamento cruzado de tags**: a tag que o handler de tickets escrevia "vazava" para o log de erro do handler de projects, porque no fundo era o mesmo objeto em memória.
2. **Data race de verdade**: escrita concorrente no mesmo mapa Go sem sincronização é undefined behavior — sob `-race` isso acusa corrupção, e em produção pode até derrubar o processo com `fatal error: concurrent map writes`.

Isso foi reproduzido de forma concreta: revertendo o fix e rodando com `-race`, o teste realmente aponta a escrita concorrente na mesma posição de memória — não é um bug teórico.

### Um segundo bug, independente, na mesma área

Além disso, a função interna que formata a linha de log (`printf`) recebia as tags passadas diretamente na chamada (`logging.Info(ctx, "mensagem", logging.Tags{...})`) mas **nunca usava esse parâmetro** — ele existia na assinatura da função só decorativamente. Resultado: qualquer tag passada assim (sem passar por `WithTag`) era **silenciosamente descartada** do log, tanto no formato JSON quanto no registro enviado pro OTEL/Signoz.

### O bug pego por revisão adversarial antes de abrir este PR

Ao corrigir o segundo bug (fazer a lib realmente usar essas tags), a primeira versão aplicava as tags do ctx e as tags da chamada em **duas operações separadas**. Só que nem o slog nem o otel removem chaves duplicadas — então se uma tag da chamada tivesse o **mesmo nome** de uma tag já no ctx (o caso mais óbvio: `Err()` sempre seta `error=true`, e se o ctx já tivesse uma tag `error`), a chave saía **duplicada na saída** em vez da mais específica sobrepor a outra. Uma revisão adversarial rodada em cima do diff pegou exatamente isso antes de reportar como pronto — corrigido mesclando as duas fontes de tags num único mapa antes de emitir.

## Em uma frase

O contexto compartilhado entre handlers concorrentes estava sendo tratado como se fosse "de uma goroutine só" — mutável e sem isolamento — quando na real ele é uma árvore compartilhada; a correção faz cada goroutine trabalhar sobre sua própria cópia das tags, e faz a lib realmente honrar as tags passadas na chamada (sem duplicar quando colidem com as do contexto).

## Escopo

Corresponde a T8/OBS-01 da spec `pd-2829-contacts-upsert-batching` do `crewhu-trends-api` (Fase B, gated antes do bump para v0.0.10 naquele repo — T9, separado).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — 8 testes novos, todos provados vermelho→verde contra o código original (incluindo data race real detectada pelo `-race`)
- [x] `gofmt -l .` limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)